### PR TITLE
updated variable name for secretKey

### DIFF
--- a/utils/getHumeAccessToken.ts
+++ b/utils/getHumeAccessToken.ts
@@ -4,7 +4,7 @@ import { fetchAccessToken } from "@humeai/voice";
 export const getHumeAccessToken = async () => {
     const accessToken = await fetchAccessToken({
     apiKey: String(process.env.HUME_API_KEY),
-    clientSecret: String(process.env.HUME_CLIENT_SECRET),
+    secretKey: String(process.env.HUME_CLIENT_SECRET),
   });
 
   if (accessToken === 'undefined') {


### PR DESCRIPTION
Fixed an issue #5  in the local setup for running Hume AI by updating the clientSecret token in the getHumeAccessToken function to secretKey.